### PR TITLE
Add “break” lines to case labels in `scale_hqx(…)`

### DIFF
--- a/depixelate/main.mm
+++ b/depixelate/main.mm
@@ -32,14 +32,21 @@ static bool scale_xbrz(const void* srcData, void* dstData, int width, int height
 static bool scale_hqx(const void* srcData, void* dstData, int width, int height, int scale)
 {
     hqxInit();
-    switch(scale)
+    switch (scale)
     {
-        case 2:
+        case 2: {
             hq2x_32((uint32_t*)srcData, (uint32_t*)dstData, width, height);
-        case 3:
+            break;
+        }
+        case 3: {
             hq3x_32((uint32_t*)srcData, (uint32_t*)dstData, width, height);
+            break;
+        }
         case 4:
+        default: {
             hq4x_32((uint32_t*)srcData, (uint32_t*)dstData, width, height);
+            break;
+        }
     }
     return true;
 }


### PR DESCRIPTION
Without these, execution on a matching “case” label can fall through, calling another subsequent `hq{2,3,4}x_32(…)` function undesirably. There’s already some example code in the codebase, for another command-line tool in the `hqx` subdirectory, that has “break” statements in place here:

https://github.com/kstenerud/depixelate/blob/master/depixelate/hqx/hqx.c#L96-L107

… which avoids the fall-through behavior.